### PR TITLE
Reduce server load by throttling & smoothing

### DIFF
--- a/main.js
+++ b/main.js
@@ -40,6 +40,7 @@ var checkFeatureSupport = function(){
 // updates synth location, pitch & filter frequency on every animation
 // frame. this is the only place that synth.coords is written to.
 function updateSynths(){
+    window.requestAnimationFrame(updateSynths);
     for (var cid in synths){
         var synth = synths[cid],
             coef = SMOOTHING_COEFFICIENT,
@@ -82,7 +83,6 @@ function updateSynths(){
         });
 
     }
-    window.requestAnimationFrame(updateSynths);
 }
 
 $(document).ready(function() {

--- a/main.js
+++ b/main.js
@@ -184,14 +184,16 @@ var playSynth = function(data){
   var n = synthmap(data.x,data.y);
   _x=n[0];
   _y=n[1];
-  if(synths[data.id]){
-    if(synths[data.id].oscillator && synths[data.id].filter){
-      synths[data.id].oscillator.frequency.value=_x;
-      synths[data.id].filter.frequency.value=_y;
-      synths[data.id].gainNode.gain.value=(0.2+data.y/3);
-    if(!synths[data.id].started){
-       synths[data.id].started = true;
-       synths[data.id].oscillator.start(0);
+
+  var synth = synths[data.id];
+  if(synth){
+    if(synth.oscillator && synth.filter){
+      synth.oscillator.frequency.value=_x;
+      synth.filter.frequency.value=_y;
+      synth.gainNode.gain.value=(0.2+data.y/3);
+    if(!synth.started){
+       synth.started = true;
+       synth.oscillator.start(0);
       }
     }
   }

--- a/main.js
+++ b/main.js
@@ -47,8 +47,8 @@ function updateSynths(){
 
         if(!synth.playing) {
             synth.gainNode.gain.value=0;
-            synths[client_id].coords.x = synths[client_id].coords.y = null;
-            $('#synth_'+client_id).css({
+            synths[cid].coords.x = synths[cid].coords.y = null;
+            $('#synth_'+cid).css({
                 'opacity' : '0.2'
             });
             continue;
@@ -77,7 +77,7 @@ function updateSynths(){
         $('#synth_'+cid).css({
             'left' : (synth.coords.x*$(window).width()-20) + 'px',
             'top' : synth.coords.y*$(window).height()-20 + 'px',
-            'background-color': col,
+            'background-color': synth.color,
             'opacity' : '0.7'
         });
 

--- a/main.js
+++ b/main.js
@@ -57,6 +57,32 @@ $(document).ready(function() {
     });
 });
 
+// calls fun at most once every ms.
+function throttle(ms, fun){
+    var then = performance.now(),
+        that = this,
+        lastArgs = null,
+        timeout = null;
+
+    return function(){
+        var now = performance.now(),
+            args = Array.prototype.slice.apply(arguments);
+        if(now - then > ms){
+            fun.apply(that, args);
+            then = now;
+            // TODO: clear the timeout here?
+        } else {
+            // if it hasn't been long enough, schedule the most recent function
+            // call to fire after `ms` have passed.
+            lastArgs = args;
+            timeout && window.clearTimeout(timeout);
+            timeout = window.setTimeout(function(){
+                fun.apply(that, args);
+            }, ms);
+        }
+    };
+}
+
 
 var touchActivate = function(event){
   pressed= true;
@@ -93,6 +119,7 @@ var touchDeactivate = function(){
 //socketio
 
 var socket = io.connect('http://'+window.location.hostname);
+socket.emit = throttle.call(socket, 100, socket.emit);
 
 function synthmap(x,y){
   tx = 40*Math.pow(2,x*5);

--- a/main.js
+++ b/main.js
@@ -107,7 +107,7 @@ var touchActivate = function(event){
 var touchDeactivate = function(){
   pressed=false;
   socket.emit('silent',{state:"stop"});
-  synths[client_id][2].gain.value=0;
+  synths[client_id].gainNode.gain.value=0;
   $('#synth_'+client_id).css({
     'opacity' : '0.2'
   });
@@ -159,7 +159,7 @@ socket.on('silent',function(id){
   });
 
   console.log(id);
-  synths[id][2].gain.value=0;
+  synths[id].gainNode.gain.value=0;
 });
 
 socket.on('move', function (data) {
@@ -185,13 +185,13 @@ var playSynth = function(data){
   _x=n[0];
   _y=n[1];
   if(synths[data.id]){
-    if(synths[data.id][0] && synths[data.id][1]){
-      synths[data.id][0].frequency.value=_x;
-      synths[data.id][1].frequency.value=_y;
-      synths[data.id][2].gain.value=(0.2+data.y/3);
-      if(!synths[data.id][3]){
-       synths[data.id][3] = true;
-       synths[data.id][0].start(0);
+    if(synths[data.id].oscillator && synths[data.id].filter){
+      synths[data.id].oscillator.frequency.value=_x;
+      synths[data.id].filter.frequency.value=_y;
+      synths[data.id].gainNode.gain.value=(0.2+data.y/3);
+    if(!synths[data.id].started){
+       synths[data.id].started = true;
+       synths[data.id].oscillator.start(0);
       }
     }
   }
@@ -238,7 +238,12 @@ function prepSynths(){
   filter.connect(gainNode);
   gainNode.connect(context.destination);
   var started = false;
-  return [oscillator, filter, gainNode, started];
+  return {
+      oscillator: oscillator,
+      filter: filter,
+      gainNode: gainNode,
+      started: started
+  };
 }
 
 function hsvToRgb(h, s, v){

--- a/main.js
+++ b/main.js
@@ -230,9 +230,9 @@ var playSynth = function(data){
 socket.on('close', function (id) {
   console.log('disconnect ' + id);
   if(id in synths){
-    if(synths[id][3]){
-      synths[id][0].stop(0);
-      synths[id][0].disconnect(0);
+    if(synths[id].started){
+        synths[id].oscillator.stop(0);
+        synths[id].oscillator.disconnect(0);
     }
   }
   $('#synth_'+id).remove();

--- a/main.js
+++ b/main.js
@@ -187,18 +187,16 @@ var playSynth = function(data){
 
   var synth = synths[data.id];
   if(synth){
-    if(synth.oscillator && synth.filter){
-      synth.oscillator.frequency.value=_x;
-      synth.filter.frequency.value=_y;
-      synth.gainNode.gain.value=(0.2+data.y/3);
-    if(!synth.started){
-       synth.started = true;
-       synth.oscillator.start(0);
-      }
-    }
+    synth.oscillator.frequency.value=_x;
+    synth.filter.frequency.value=_y;
+    synth.gainNode.gain.value=(0.2+data.y/3);
+  if(!synth.started){
+     synth.started = true;
+     synth.oscillator.start(0);
   }
 
 }
+};
 
 socket.on('close', function (id) {
   console.log('disconnect ' + id);


### PR DESCRIPTION
These commits might let the app scale higher by:

- throttling the number of messages sent from clients to server (and thus broadcast from server to clients)
- smoothing out the coordinate data received by the clients in order to smooth out the jitter introduced by the throttling.

Haven't been able to test on any modern mobile devices. 
Requires browser to support the [performance interface](https://developer.mozilla.org/en-US/docs/Web/API/Performance/) and [requestAnimationFrame](https://developer.mozilla.org/en-US/docs/Web/API/window/requestAnimationFrame).

Maybe the audio stuff shouldn't be in the requestAnimationFrame loop...